### PR TITLE
Support input variables via command line flags

### DIFF
--- a/src/Cake.Terraform.Tests/TerraformApplyTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformApplyTests.cs
@@ -4,6 +4,8 @@ using Xunit;
 
 namespace Cake.Terraform.Tests
 {
+    using System.Collections.Generic;
+
     public class TerraformApplyTests
     {
         public class TheExecutable
@@ -76,8 +78,23 @@ namespace Cake.Terraform.Tests
 
                 Assert.Contains("apply", result.Args);
             }
+
+            [Fact]
+            public void Should_set_input_variables()
+            {
+                var fixture = new TerraformApplyFixture();
+                fixture.Settings = new TerraformApplySettings
+                {
+                    InputVariables = new Dictionary<string, string>
+                    {
+                        { "access_key", "foo" },
+                        { "secret_key", "bar" }
+                    }
+                };
+                var result = fixture.Run();
+
+                Assert.Contains("-var 'access_key=foo' -var 'secret_key=bar'", result.Args);
+            }
         }
-
-
     }
 }

--- a/src/Cake.Terraform.Tests/TerraformApplyTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformApplyTests.cs
@@ -93,7 +93,7 @@ namespace Cake.Terraform.Tests
                 };
                 var result = fixture.Run();
 
-                Assert.Contains("-var 'access_key=foo' -var 'secret_key=bar'", result.Args);
+                Assert.Contains("-var \"access_key=foo\" -var \"secret_key=bar\"", result.Args);
             }
         }
     }

--- a/src/Cake.Terraform.Tests/TerraformPlanTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformPlanTests.cs
@@ -142,7 +142,7 @@ namespace Cake.Terraform.Tests
                 };
                 var result = fixture.Run();
 
-                Assert.Contains("-var 'access_key=foo' -var 'secret_key=bar'", result.Args);
+                Assert.Contains("-var \"access_key=foo\" -var \"secret_key=bar\"", result.Args);
             }
         }
     }

--- a/src/Cake.Terraform.Tests/TerraformPlanTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformPlanTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Cake.Core;
 using Cake.Testing;
 using Xunit;
@@ -125,6 +126,23 @@ namespace Cake.Terraform.Tests
                 var result = fixture.Run();
 
                 Assert.DoesNotContain("-parallelism", result.Args);
+            }
+
+            [Fact]
+            public void Should_set_input_variables()
+            {
+                var fixture = new TerraformPlanFixture();
+                fixture.Settings = new TerraformPlanSettings
+                {
+                    InputVariables = new Dictionary<string, string>
+                    {
+                        { "access_key", "foo" },
+                        { "secret_key", "bar" }
+                    }
+                };
+                var result = fixture.Run();
+
+                Assert.Contains("-var 'access_key=foo' -var 'secret_key=bar'", result.Args);
             }
         }
     }

--- a/src/Cake.Terraform/TerraformApplyRunner.cs
+++ b/src/Cake.Terraform/TerraformApplyRunner.cs
@@ -19,7 +19,7 @@ namespace Cake.Terraform
             {
                 foreach (var inputVariable in settings.InputVariables)
                 {
-                    builder.Append($"-var '{inputVariable.Key}={inputVariable.Value}'");
+                    builder.AppendSwitchQuoted("-var", $"{inputVariable.Key}={inputVariable.Value}");
                 }
             }
 

--- a/src/Cake.Terraform/TerraformApplyRunner.cs
+++ b/src/Cake.Terraform/TerraformApplyRunner.cs
@@ -14,6 +14,15 @@ namespace Cake.Terraform
         public void Run(TerraformApplySettings settings)
         {
             var builder = new ProcessArgumentBuilder().Append("apply");
+
+            if (settings.InputVariables != null)
+            {
+                foreach (var inputVariable in settings.InputVariables)
+                {
+                    builder.Append($"-var '{inputVariable.Key}={inputVariable.Value}'");
+                }
+            }
+
             Run(settings, builder);
         }
     }

--- a/src/Cake.Terraform/TerraformApplySettings.cs
+++ b/src/Cake.Terraform/TerraformApplySettings.cs
@@ -2,9 +2,17 @@
 
 namespace Cake.Terraform
 {
+    using System.Collections.Generic;
+
     public class TerraformApplySettings : TerraformSettings
     {
         public int Parallelism { get; set; }
+
         public FilePath Plan { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the input variables. https://www.terraform.io/intro/getting-started/variables.html
+        /// </summary>
+        public Dictionary<string, string> InputVariables { get; set; }
     }
 }

--- a/src/Cake.Terraform/TerraformPlanRunner.cs
+++ b/src/Cake.Terraform/TerraformPlanRunner.cs
@@ -24,7 +24,14 @@ namespace Cake.Terraform
             if (settings.Parallelism > 0)
             {
                 builder = builder.Append($"-parallelism={settings.Parallelism}");
+            }
 
+            if (settings.InputVariables != null)
+            {
+                foreach (var inputVariable in settings.InputVariables)
+                {
+                    builder.Append($"-var '{inputVariable.Key}={inputVariable.Value}'");
+                }
             }
 
             Run(settings, builder);

--- a/src/Cake.Terraform/TerraformPlanRunner.cs
+++ b/src/Cake.Terraform/TerraformPlanRunner.cs
@@ -30,7 +30,7 @@ namespace Cake.Terraform
             {
                 foreach (var inputVariable in settings.InputVariables)
                 {
-                    builder.Append($"-var '{inputVariable.Key}={inputVariable.Value}'");
+                    builder.AppendSwitchQuoted("-var", $"{inputVariable.Key}={inputVariable.Value}");
                 }
             }
 

--- a/src/Cake.Terraform/TerraformPlanSettings.cs
+++ b/src/Cake.Terraform/TerraformPlanSettings.cs
@@ -2,9 +2,17 @@
 
 namespace Cake.Terraform
 {
+    using System.Collections.Generic;
+
     public class TerraformPlanSettings : TerraformSettings
     {
         public FilePath OutFile { get; set; }
+
         public int Parallelism { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the input variables. https://www.terraform.io/intro/getting-started/variables.html
+        /// </summary>
+        public Dictionary<string, string> InputVariables { get; set; }
     }
 }


### PR DESCRIPTION
Allows passing of input variables via [command line flags](https://www.terraform.io/intro/getting-started/variables.html#command-line-flags). Implemented for `plan` and `apply`.

Example:

```csharp
var settings = new TerraformApplySettings
{
    InputVariables = new Dictionary<string, string>
    {
         { "access_key", "foo" },
         { "secret_key", "bar" }
    }
};
```