### PR TITLE
Add variables file support

### DIFF
--- a/src/Cake.Terraform.Tests/TerraformApplyTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformApplyTests.cs
@@ -95,6 +95,26 @@ namespace Cake.Terraform.Tests
 
                 Assert.Contains("-var \"access_key=foo\" -var \"secret_key=bar\"", result.Args);
             }
+
+            [Fact]
+            public void Should_set_input_variables_file()
+            {
+                var fixture = new TerraformApplyFixture
+                {
+                    Settings = new TerraformApplySettings
+                    {
+                        InputVarieablesFile = "./aws-creds.json",
+                        InputVariables = new Dictionary<string, string>
+                        {
+                            {"access_key", "foo"},
+                            {"secret_key", "bar"}
+                        }
+                    }
+                };
+                var result = fixture.Run();
+
+                Assert.Contains("-var-file \"./aws-creds.json\" -var \"access_key=foo\" -var \"secret_key=bar\"", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Terraform.Tests/TerraformApplyTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformApplyTests.cs
@@ -103,7 +103,7 @@ namespace Cake.Terraform.Tests
                 {
                     Settings = new TerraformApplySettings
                     {
-                        InputVarieablesFile = "./aws-creds.json",
+                        InputVariablesFile = "./aws-creds.json",
                         InputVariables = new Dictionary<string, string>
                         {
                             {"access_key", "foo"},

--- a/src/Cake.Terraform.Tests/TerraformDestroyTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformDestroyTests.cs
@@ -111,6 +111,26 @@ namespace Cake.Terraform.Tests
 
                 Assert.Contains("-var \"access_key=foo\" -var \"secret_key=bar\"", result.Args);
             }
+
+            [Fact]
+            public void Should_set_input_variables_file()
+            {
+                var fixture = new TerraformDestroyFixture
+                {
+                    Settings = new TerraformDestroySettings
+                    {
+                        InputVarieablesFile = "./aws-creds.json",
+                        InputVariables = new Dictionary<string, string>
+                        {
+                            {"access_key", "foo"},
+                            {"secret_key", "bar"}
+                        }
+                    }
+                };
+                var result = fixture.Run();
+
+                Assert.Contains("-var-file \"./aws-creds.json\" -var \"access_key=foo\" -var \"secret_key=bar\"", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Terraform.Tests/TerraformDestroyTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformDestroyTests.cs
@@ -119,7 +119,7 @@ namespace Cake.Terraform.Tests
                 {
                     Settings = new TerraformDestroySettings
                     {
-                        InputVarieablesFile = "./aws-creds.json",
+                        InputVariablesFile = "./aws-creds.json",
                         InputVariables = new Dictionary<string, string>
                         {
                             {"access_key", "foo"},

--- a/src/Cake.Terraform.Tests/TerraformPlanTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformPlanTests.cs
@@ -146,6 +146,26 @@ namespace Cake.Terraform.Tests
             }
 
             [Fact]
+            public void Should_set_input_variables_file()
+            {
+                var fixture = new TerraformPlanFixture
+                {
+                    Settings = new TerraformPlanSettings
+                    {
+                        InputVarieablesFile = "./aws-creds.json",
+                        InputVariables = new Dictionary<string, string>
+                        {
+                            {"access_key", "foo"},
+                            {"secret_key", "bar"}
+                        }
+                    }
+                };
+                var result = fixture.Run();
+
+                Assert.Contains("-var-file \"./aws-creds.json\" -var \"access_key=foo\" -var \"secret_key=bar\"", result.Args);
+            }
+
+            [Fact]
             public void Should_set_destroy_flag_when_set_to_true()
             {
                 var fixture = new TerraformPlanFixture();

--- a/src/Cake.Terraform.Tests/TerraformPlanTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformPlanTests.cs
@@ -152,7 +152,7 @@ namespace Cake.Terraform.Tests
                 {
                     Settings = new TerraformPlanSettings
                     {
-                        InputVarieablesFile = "./aws-creds.json",
+                        InputVariablesFile = "./aws-creds.json",
                         InputVariables = new Dictionary<string, string>
                         {
                             {"access_key", "foo"},

--- a/src/Cake.Terraform/TerraformApplyRunner.cs
+++ b/src/Cake.Terraform/TerraformApplyRunner.cs
@@ -15,6 +15,11 @@ namespace Cake.Terraform
         {
             var builder = new ProcessArgumentBuilder().Append("apply");
 
+            if (!string.IsNullOrEmpty(settings.InputVarieablesFile))
+            {
+                builder.AppendSwitchQuoted("-var-file", $"{settings.InputVarieablesFile}");
+            }
+
             if (settings.InputVariables != null)
             {
                 foreach (var inputVariable in settings.InputVariables)

--- a/src/Cake.Terraform/TerraformApplyRunner.cs
+++ b/src/Cake.Terraform/TerraformApplyRunner.cs
@@ -15,9 +15,9 @@ namespace Cake.Terraform
         {
             var builder = new ProcessArgumentBuilder().Append("apply");
 
-            if (!string.IsNullOrEmpty(settings.InputVarieablesFile))
+            if (!string.IsNullOrEmpty(settings.InputVariablesFile))
             {
-                builder.AppendSwitchQuoted("-var-file", $"{settings.InputVarieablesFile}");
+                builder.AppendSwitchQuoted("-var-file", $"{settings.InputVariablesFile}");
             }
 
             if (settings.InputVariables != null)

--- a/src/Cake.Terraform/TerraformApplySettings.cs
+++ b/src/Cake.Terraform/TerraformApplySettings.cs
@@ -14,5 +14,11 @@ namespace Cake.Terraform
         ///     Gets or sets the input variables. https://www.terraform.io/intro/getting-started/variables.html
         /// </summary>
         public Dictionary<string, string> InputVariables { get; set; }
+
+        /// <summary>
+        /// Variables file
+        /// https://www.terraform.io/docs/configuration/variables.html#variable-files
+        /// </summary>
+        public string InputVarieablesFile { get; set; }
     }
 }

--- a/src/Cake.Terraform/TerraformApplySettings.cs
+++ b/src/Cake.Terraform/TerraformApplySettings.cs
@@ -19,6 +19,6 @@ namespace Cake.Terraform
         /// Variables file
         /// https://www.terraform.io/docs/configuration/variables.html#variable-files
         /// </summary>
-        public string InputVarieablesFile { get; set; }
+        public string InputVariablesFile { get; set; }
     }
 }

--- a/src/Cake.Terraform/TerraformDestroyRunner.cs
+++ b/src/Cake.Terraform/TerraformDestroyRunner.cs
@@ -20,9 +20,9 @@ namespace Cake.Terraform
                 builder = builder.Append("-force");
             }
 
-            if (!string.IsNullOrEmpty(settings.InputVarieablesFile))
+            if (!string.IsNullOrEmpty(settings.InputVariablesFile))
             {
-                builder.AppendSwitchQuoted("-var-file", $"{settings.InputVarieablesFile}");
+                builder.AppendSwitchQuoted("-var-file", $"{settings.InputVariablesFile}");
             }
 
             if (settings.InputVariables != null)

--- a/src/Cake.Terraform/TerraformDestroyRunner.cs
+++ b/src/Cake.Terraform/TerraformDestroyRunner.cs
@@ -20,6 +20,11 @@ namespace Cake.Terraform
                 builder = builder.Append("-force");
             }
 
+            if (!string.IsNullOrEmpty(settings.InputVarieablesFile))
+            {
+                builder.AppendSwitchQuoted("-var-file", $"{settings.InputVarieablesFile}");
+            }
+
             if (settings.InputVariables != null)
             {
                 foreach (var inputVariable in settings.InputVariables)

--- a/src/Cake.Terraform/TerraformDestroySettings.cs
+++ b/src/Cake.Terraform/TerraformDestroySettings.cs
@@ -13,6 +13,12 @@ namespace Cake.Terraform
         public Dictionary<string, string> InputVariables { get; set; }
 
         /// <summary>
+        /// Variables file
+        /// https://www.terraform.io/docs/configuration/variables.html#variable-files
+        /// </summary>
+        public string InputVarieablesFile { get; set; }
+
+        /// <summary>
         /// If set to true, then the destroy confirmation will not be shown.
         /// </summary>
         public bool Force { get; set; }

--- a/src/Cake.Terraform/TerraformDestroySettings.cs
+++ b/src/Cake.Terraform/TerraformDestroySettings.cs
@@ -16,7 +16,7 @@ namespace Cake.Terraform
         /// Variables file
         /// https://www.terraform.io/docs/configuration/variables.html#variable-files
         /// </summary>
-        public string InputVarieablesFile { get; set; }
+        public string InputVariablesFile { get; set; }
 
         /// <summary>
         /// If set to true, then the destroy confirmation will not be shown.

--- a/src/Cake.Terraform/TerraformPlanRunner.cs
+++ b/src/Cake.Terraform/TerraformPlanRunner.cs
@@ -30,9 +30,9 @@ namespace Cake.Terraform
                 builder = builder.Append("-destroy");
             }
 
-            if (!string.IsNullOrEmpty(settings.InputVarieablesFile))
+            if (!string.IsNullOrEmpty(settings.InputVariablesFile))
             {
-                builder.AppendSwitchQuoted("-var-file", $"{settings.InputVarieablesFile}");
+                builder.AppendSwitchQuoted("-var-file", $"{settings.InputVariablesFile}");
             }
 
             if (settings.InputVariables != null)

--- a/src/Cake.Terraform/TerraformPlanRunner.cs
+++ b/src/Cake.Terraform/TerraformPlanRunner.cs
@@ -30,6 +30,11 @@ namespace Cake.Terraform
                 builder = builder.Append("-destroy");
             }
 
+            if (!string.IsNullOrEmpty(settings.InputVarieablesFile))
+            {
+                builder.AppendSwitchQuoted("-var-file", $"{settings.InputVarieablesFile}");
+            }
+
             if (settings.InputVariables != null)
             {
                 foreach (var inputVariable in settings.InputVariables)

--- a/src/Cake.Terraform/TerraformPlanSettings.cs
+++ b/src/Cake.Terraform/TerraformPlanSettings.cs
@@ -19,7 +19,7 @@ namespace Cake.Terraform
         /// Variables file
         /// https://www.terraform.io/docs/configuration/variables.html#variable-files
         /// </summary>
-        public string InputVarieablesFile { get; set; }
+        public string InputVariablesFile { get; set; }
 
         /// <summary>
         /// If set to true, generates a plan to destroy all the known resources

--- a/src/Cake.Terraform/TerraformPlanSettings.cs
+++ b/src/Cake.Terraform/TerraformPlanSettings.cs
@@ -16,6 +16,12 @@ namespace Cake.Terraform
         public Dictionary<string, string> InputVariables { get; set; }
 
         /// <summary>
+        /// Variables file
+        /// https://www.terraform.io/docs/configuration/variables.html#variable-files
+        /// </summary>
+        public string InputVarieablesFile { get; set; }
+
+        /// <summary>
         /// If set to true, generates a plan to destroy all the known resources
         /// </summary>
         public bool Destroy { get; set; }


### PR DESCRIPTION
Variables file is a very handy way to keep input parameters in good order
https://www.terraform.io/docs/configuration/variables.html#variable-files

This PR introduces support for specifying a variables file. 

Disclaimer: `terraform` actually supports multiple variables files to be specified but I personally do not see a need for supporting multiple files. Single var file is enough for 100% of my use cases. If there's a need for multiple variable files - open another PR or let me know.