### PR TITLE
Add support for backend config overrides for terraform init

### DIFF
--- a/src/Cake.Terraform.Tests/TerraformInitTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformInitTests.cs
@@ -1,4 +1,5 @@
-﻿using Cake.Core;
+﻿using System.Collections.Generic;
+using Cake.Core;
 using Cake.Testing;
 using Xunit;
 
@@ -75,6 +76,26 @@ namespace Cake.Terraform.Tests
                 var result = fixture.Run();
 
                 Assert.Contains("init", result.Args);
+            }
+
+            [Fact]
+            public void Should_pass_backend_config_overrides()
+            {
+                var fixture = new TerraformInitFixture();
+
+                fixture.Settings = new TerraformInitSettings
+                {
+                    BackendConfigOverrides = new Dictionary<string, string>
+                    {
+                        { "key", "value" },
+                        { "foo", "bar" },
+                    }
+                };
+
+                var result = fixture.Run();
+
+                Assert.Contains("-backend-config \"key=value\"", result.Args);
+                Assert.Contains("-backend-config \"foo=bar\"", result.Args);
             }
         }
     }

--- a/src/Cake.Terraform/TerraformInitRunner.cs
+++ b/src/Cake.Terraform/TerraformInitRunner.cs
@@ -13,7 +13,19 @@ namespace Cake.Terraform
 
         public void Run(TerraformInitSettings settings)
         {
-            var builder = new ProcessArgumentBuilder().Append("init");
+            var builder =
+                new ProcessArgumentBuilder()
+                    .Append("init");
+
+            if (settings.BackendConfigOverrides != null)
+            {
+                foreach (var pair in settings.BackendConfigOverrides)
+                {
+                    // https://www.terraform.io/docs/commands/init.html#backend-config-value
+                    builder.AppendSwitchQuoted("-backend-config", $"{pair.Key}={pair.Value}");
+                }
+            }
+
             Run(settings, builder);
         }
     }

--- a/src/Cake.Terraform/TerraformInitSettings.cs
+++ b/src/Cake.Terraform/TerraformInitSettings.cs
@@ -1,6 +1,13 @@
-﻿namespace Cake.Terraform
+﻿using System.Collections.Generic;
+
+namespace Cake.Terraform
 {
     public class TerraformInitSettings : TerraformSettings
     {
+        /// <summary>
+        /// A set of backend config key-value overrides to be passed to `terraform init`
+        /// <see>https://www.terraform.io/docs/commands/init.html#backend-config-value</see>
+        /// </summary>
+        public Dictionary<string, string> BackendConfigOverrides { get; set; }
     }
 }


### PR DESCRIPTION
enables support for overriding backend config when using `tf init`

ie...

```bash
$ terraform init -backend-config "key=value"
```

see https://www.terraform.io/docs/commands/init.html#backend-config-value