### PR TITLE
Add additional flags to terraform init

### DIFF
--- a/src/Cake.Terraform.Tests/TerraformInitTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformInitTests.cs
@@ -97,6 +97,58 @@ namespace Cake.Terraform.Tests
                 Assert.Contains("-backend-config \"key=value\"", result.Args);
                 Assert.Contains("-backend-config \"foo=bar\"", result.Args);
             }
+            
+            [Fact]
+            public void Should_omit_reconfigure_flag_by_default()
+            {
+                var fixture = new TerraformInitFixture();
+
+                var result = fixture.Run();
+
+                Assert.DoesNotContain("-reconfigure", result.Args);
+            }
+            
+            [Fact]
+            public void Should_include_reconfigure_flag_when_setting_is_true()
+            {
+                var fixture = new TerraformInitFixture
+                {
+                    Settings = new TerraformInitSettings
+                    {
+                        ForceReconfigure = true
+                    }
+                };
+
+                var result = fixture.Run();
+
+                Assert.Contains("-reconfigure", result.Args);
+            }
+            
+            [Fact]
+            public void Should_omit_force_copy_flag_by_default()
+            {
+                var fixture = new TerraformInitFixture();
+
+                var result = fixture.Run();
+
+                Assert.DoesNotContain("-force-copy", result.Args);
+            }
+            
+            [Fact]
+            public void Should_include_force_copy_flag_when_setting_is_true()
+            {
+                var fixture = new TerraformInitFixture
+                {
+                    Settings = new TerraformInitSettings
+                    {
+                        ForceCopy = true
+                    }
+                };
+
+                var result = fixture.Run();
+
+                Assert.Contains("-force-copy", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Terraform/TerraformInitRunner.cs
+++ b/src/Cake.Terraform/TerraformInitRunner.cs
@@ -26,6 +26,16 @@ namespace Cake.Terraform
                 }
             }
 
+            if (settings.ForceCopy)
+            {
+                builder.Append("-force-copy");
+            }
+
+            if (settings.ForceReconfigure)
+            {
+                builder.Append("-reconfigure");
+            }
+
             Run(settings, builder);
         }
     }

--- a/src/Cake.Terraform/TerraformInitSettings.cs
+++ b/src/Cake.Terraform/TerraformInitSettings.cs
@@ -9,5 +9,18 @@ namespace Cake.Terraform
         /// <see>https://www.terraform.io/docs/commands/init.html#backend-config-value</see>
         /// </summary>
         public Dictionary<string, string> BackendConfigOverrides { get; set; }
+        
+        /// <summary>
+        /// Reconfigure the backend, ignoring any saved configuration.
+        /// <see>https://www.terraform.io/docs/commands/init.html#reconfigure</see>
+        /// </summary>
+        public bool ForceReconfigure { get; set; }
+        
+        /// <summary>
+        /// Suppress prompts about copying state data. This is equivalent to providing
+        /// a "yes" to all confirmation prompts.
+        /// <see>https://www.terraform.io/docs/commands/init.html#force-copy</see>
+        /// </summary>
+        public bool ForceCopy { get; set; }
     }
 }


### PR DESCRIPTION
config options for appending `-force-copy` and `-reconfigure` flags to `terriform init`