### PR TITLE
Enable -auto-approve workflow that was introduced in Terraform 0.10.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+##########################################################################
+# This is the Cake bootstrapper script for Linux and OS X.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
+# Define directories.
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+TOOLS_DIR=$SCRIPT_DIR/tools
+ADDINS_DIR=$TOOLS_DIR/Addins
+MODULES_DIR=$TOOLS_DIR/Modules
+NUGET_EXE=$TOOLS_DIR/nuget.exe
+CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
+PACKAGES_CONFIG=$TOOLS_DIR/packages.config
+PACKAGES_CONFIG_MD5=$TOOLS_DIR/packages.config.md5sum
+ADDINS_PACKAGES_CONFIG=$ADDINS_DIR/packages.config
+MODULES_PACKAGES_CONFIG=$MODULES_DIR/packages.config
+
+# Define md5sum or md5 depending on Linux/OSX
+MD5_EXE=
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    MD5_EXE="md5 -r"
+else
+    MD5_EXE="md5sum"
+fi
+
+# Define default arguments.
+SCRIPT="setup.cake"
+CAKE_ARGUMENTS=()
+
+# Parse arguments.
+for i in "$@"; do
+    case $1 in
+        -s|--script) SCRIPT="$2"; shift ;;
+        --) shift; CAKE_ARGUMENTS+=("$@"); break ;;
+        *) CAKE_ARGUMENTS+=("$1") ;;
+    esac
+    shift
+done
+
+# Make sure the tools folder exist.
+if [ ! -d "$TOOLS_DIR" ]; then
+  mkdir "$TOOLS_DIR"
+fi
+
+# Make sure that packages.config exist.
+if [ ! -f "$TOOLS_DIR/packages.config" ]; then
+    echo "Downloading packages.config..."
+    curl -Lsfo "$TOOLS_DIR/packages.config" https://cakebuild.net/download/bootstrapper/packages
+    if [ $? -ne 0 ]; then
+        echo "An error occurred while downloading packages.config."
+        exit 1
+    fi
+fi
+
+# Download NuGet if it does not exist.
+if [ ! -f "$NUGET_EXE" ]; then
+    echo "Downloading NuGet..."
+    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+    if [ $? -ne 0 ]; then
+        echo "An error occurred while downloading nuget.exe."
+        exit 1
+    fi
+fi
+
+# Restore tools from NuGet.
+pushd "$TOOLS_DIR" >/dev/null
+if [ ! -f "$PACKAGES_CONFIG_MD5" ] || [ "$( cat "$PACKAGES_CONFIG_MD5" | sed 's/\r$//' )" != "$( $MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' )" ]; then
+    find . -type d ! -name . ! -name 'Cake.Bakery' | xargs rm -rf
+fi
+
+mono "$NUGET_EXE" install -ExcludeVersion
+if [ $? -ne 0 ]; then
+    echo "Could not restore NuGet tools."
+    exit 1
+fi
+
+$MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' >| "$PACKAGES_CONFIG_MD5"
+
+popd >/dev/null
+
+# Restore addins from NuGet.
+if [ -f "$ADDINS_PACKAGES_CONFIG" ]; then
+    pushd "$ADDINS_DIR" >/dev/null
+
+    mono "$NUGET_EXE" install -ExcludeVersion
+    if [ $? -ne 0 ]; then
+        echo "Could not restore NuGet addins."
+        exit 1
+    fi
+
+    popd >/dev/null
+fi
+
+# Restore modules from NuGet.
+if [ -f "$MODULES_PACKAGES_CONFIG" ]; then
+    pushd "$MODULES_DIR" >/dev/null
+
+    mono "$NUGET_EXE" install -ExcludeVersion
+    if [ $? -ne 0 ]; then
+        echo "Could not restore NuGet modules."
+        exit 1
+    fi
+
+    popd >/dev/null
+fi
+
+# Make sure that Cake has been installed.
+if [ ! -f "$CAKE_EXE" ]; then
+    echo "Could not find Cake.exe at '$CAKE_EXE'."
+    exit 1
+fi
+
+# Start Cake
+exec mono "$CAKE_EXE" $SCRIPT "${CAKE_ARGUMENTS[@]}"

--- a/src/Cake.Terraform.Tests/TerraformApplyTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformApplyTests.cs
@@ -60,7 +60,7 @@ namespace Cake.Terraform.Tests
             [Fact]
             public void Should_find_linux_executable()
             {
-                var fixture = new TerraformPlanFixture(PlatformFamily.Linux);
+                var fixture = new TerraformApplyFixture(PlatformFamily.Linux);
                 fixture.Environment.Platform.Family = PlatformFamily.Linux;
 
 

--- a/src/Cake.Terraform.Tests/TerraformApplyTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformApplyTests.cs
@@ -115,6 +115,20 @@ namespace Cake.Terraform.Tests
 
                 Assert.Contains("-var-file \"./aws-creds.json\" -var \"access_key=foo\" -var \"secret_key=bar\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Append_Auto_Approve_When_AutoApprove_Is_True()
+            {
+                var fixture = new TerraformApplyFixture {
+                    Settings = new TerraformApplySettings {
+                        AutoApprove = true
+                    }
+                };
+
+                var result = fixture.Run();
+
+                Assert.Contains("-auto-approve", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Terraform/TerraformApplyRunner.cs
+++ b/src/Cake.Terraform/TerraformApplyRunner.cs
@@ -25,7 +25,7 @@ namespace Cake.Terraform
             // Use Plan if it exists.
             if (settings.Plan != null)
             {
-                builder.Append(settings.Plan);
+                builder.Append(settings.Plan.FullPath);
             }
 
             if (!string.IsNullOrEmpty(settings.InputVariablesFile))

--- a/src/Cake.Terraform/TerraformApplyRunner.cs
+++ b/src/Cake.Terraform/TerraformApplyRunner.cs
@@ -16,6 +16,18 @@ namespace Cake.Terraform
             var builder = new ProcessArgumentBuilder()
                 .Append("apply");
 
+            // Order of AutoApprove and Plan are important.
+            if (settings.AutoApprove)
+            {
+                builder.Append("-auto-approve");
+            }
+
+            // Use Plan if it exists.
+            if (settings.Plan != null)
+            {
+                builder.Append(settings.Plan);
+            }
+
             if (!string.IsNullOrEmpty(settings.InputVariablesFile))
             {
                 builder.AppendSwitchQuoted("-var-file", $"{settings.InputVariablesFile}");
@@ -27,11 +39,6 @@ namespace Cake.Terraform
                 {
                     builder.AppendSwitchQuoted("-var", $"{inputVariable.Key}={inputVariable.Value}");
                 }
-            }
-
-            if (settings.AutoApprove)
-            {
-                builder.Append("-auto-approve");
             }
 
             Run(settings, builder);

--- a/src/Cake.Terraform/TerraformApplyRunner.cs
+++ b/src/Cake.Terraform/TerraformApplyRunner.cs
@@ -13,7 +13,8 @@ namespace Cake.Terraform
 
         public void Run(TerraformApplySettings settings)
         {
-            var builder = new ProcessArgumentBuilder().Append("apply");
+            var builder = new ProcessArgumentBuilder()
+                .Append("apply");
 
             if (!string.IsNullOrEmpty(settings.InputVariablesFile))
             {
@@ -26,6 +27,11 @@ namespace Cake.Terraform
                 {
                     builder.AppendSwitchQuoted("-var", $"{inputVariable.Key}={inputVariable.Value}");
                 }
+            }
+
+            if (settings.AutoApprove)
+            {
+                builder.Append("-auto-approve");
             }
 
             Run(settings, builder);

--- a/src/Cake.Terraform/TerraformApplySettings.cs
+++ b/src/Cake.Terraform/TerraformApplySettings.cs
@@ -20,5 +20,11 @@ namespace Cake.Terraform
         /// https://www.terraform.io/docs/configuration/variables.html#variable-files
         /// </summary>
         public string InputVariablesFile { get; set; }
+
+        /// <summary>
+        /// Skip interactive approval of plan before applying.
+        /// https://www.terraform.io/docs/commands/apply.html#auto-approve
+        /// </summary>
+        public bool AutoApprove { get; set; }
     }
 }

--- a/src/Cake.Terraform/TerraformRunner.cs
+++ b/src/Cake.Terraform/TerraformRunner.cs
@@ -22,10 +22,7 @@ namespace Cake.Terraform
 
         protected override IEnumerable<string> GetToolExecutableNames()
         {
-
-            return new []  { _platform.IsUnix() ? "terraform" : "terraform.exe" };
+            return new[] { _platform.IsUnix() ? "terraform" : "terraform.exe" };
         }
-
-
     }
 }


### PR DESCRIPTION
[Terraform 0.10.0](https://www.terraform.io/upgrade-guides/0-10.html) introduced an additional -_auto-approve_ workflow with the Apply command. 

As of [Terraform 0.11.0](https://www.terraform.io/upgrade-guides/0-11.html) the default behaviour is to stop execution and await user input confirmation in order to continue.

Adding _-auto-approve_ bypasses this behaviour.  