### PR TITLE
Adding support for -parallelism and plans to terraform apply

### DIFF
--- a/src/Cake.Terraform.Tests/TerraformApplyTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformApplyTests.cs
@@ -115,6 +115,36 @@ namespace Cake.Terraform.Tests
 
                 Assert.Contains("-var-file \"./aws-creds.json\" -var \"access_key=foo\" -var \"secret_key=bar\"", result.Args);
             }
+
+            [Fact]
+            public void Should_set_plan_path()
+            {
+                var fixture = new TerraformApplyFixture
+                {
+                    Settings = new TerraformApplySettings
+                    {
+                        Plan = "plan.out",
+                    }
+                };
+                var result = fixture.Run();
+
+                Assert.Equal("apply \"plan.out\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_set_parallelism()
+            {
+                var fixture = new TerraformApplyFixture
+                {
+                    Settings = new TerraformApplySettings
+                    {
+                        Parallelism = 42,
+                    }
+                };
+                var result = fixture.Run();
+
+                Assert.Contains("-parallelism=42", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Terraform/TerraformApplyRunner.cs
+++ b/src/Cake.Terraform/TerraformApplyRunner.cs
@@ -28,6 +28,16 @@ namespace Cake.Terraform
                 }
             }
 
+            if (settings.Parallelism != default(int))
+            {
+                builder.AppendSwitch("-parallelism", "=", settings.Parallelism.ToString());
+            }
+
+            if (settings.Plan != null)
+            {
+                builder.AppendQuoted(settings.Plan.ToString());
+            }
+
             Run(settings, builder);
         }
     }


### PR DESCRIPTION
Both the parallelism and plan properties exist in TerraformApplySettings, neither are actually added to the argument builder and are effectively ignored. This change adds support for both parameters.