### PR TITLE
Added some missing switches to apply, init, and plan settings

### DIFF
--- a/src/Cake.Terraform.Tests/TerraformApplyTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformApplyTests.cs
@@ -157,7 +157,7 @@ namespace Cake.Terraform.Tests
                  Assert.Equal("apply \"plan.out\"", result.Args);
             }
 
-             [Fact]
+            [Fact]
             public void Should_set_parallelism()
             {
                 var fixture = new Fixture
@@ -170,6 +170,32 @@ namespace Cake.Terraform.Tests
                 var result = fixture.Run();
 
                 Assert.Contains("-parallelism=42", result.Args);
+            }
+
+            [Fact]
+            public void Should_omit_input_flag_by_default()
+            {
+                var fixture = new Fixture();
+
+                var result = fixture.Run();
+
+                Assert.DoesNotContain("-input", result.Args);
+            }
+
+            [Fact]
+            public void Should_include_input_flag_when_setting_is_false()
+            {
+                var fixture = new Fixture
+                {
+                    Settings = new TerraformApplySettings
+                    {
+                        Input = false
+                    }
+                };
+
+                var result = fixture.Run();
+
+                Assert.Contains("-input", result.Args);
             }
         }
     }

--- a/src/Cake.Terraform.Tests/TerraformInitTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformInitTests.cs
@@ -163,6 +163,58 @@ namespace Cake.Terraform.Tests
 
                 Assert.Contains("-force-copy", result.Args);
             }
+
+            [Fact]
+            public void Should_omit_input_flag_by_default()
+            {
+                var fixture = new Fixture();
+
+                var result = fixture.Run();
+
+                Assert.DoesNotContain("-input", result.Args);
+            }
+
+            [Fact]
+            public void Should_include_input_flag_when_setting_is_false()
+            {
+                var fixture = new Fixture
+                {
+                    Settings = new TerraformInitSettings
+                    {
+                        Input = false
+                    }
+                };
+
+                var result = fixture.Run();
+
+                Assert.Contains("-input", result.Args);
+            }
+
+            [Fact]
+            public void Should_omit_backend_flag_by_default()
+            {
+                var fixture = new Fixture();
+
+                var result = fixture.Run();
+
+                Assert.DoesNotContain("-backend", result.Args);
+            }
+
+            [Fact]
+            public void Should_include_backend_flag_when_setting_is_false()
+            {
+                var fixture = new Fixture
+                {
+                    Settings = new TerraformInitSettings
+                    {
+                        Backend = false
+                    }
+                };
+
+                var result = fixture.Run();
+
+                Assert.Contains("-backend", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Terraform.Tests/TerraformPlanTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformPlanTests.cs
@@ -205,6 +205,32 @@ namespace Cake.Terraform.Tests
 
                 Assert.DoesNotContain("-destroy", result.Args);
             }
+
+            [Fact]
+            public void Should_omit_input_flag_by_default()
+            {
+                var fixture = new Fixture();
+
+                var result = fixture.Run();
+
+                Assert.DoesNotContain("-input", result.Args);
+            }
+
+            [Fact]
+            public void Should_include_input_flag_when_setting_is_false()
+            {
+                var fixture = new Fixture
+                {
+                    Settings = new TerraformPlanSettings
+                    {
+                        Input = false
+                    }
+                };
+
+                var result = fixture.Run();
+
+                Assert.Contains("-input", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Terraform/Apply/TerraformApplyRunner.cs
+++ b/src/Cake.Terraform/Apply/TerraformApplyRunner.cs
@@ -44,6 +44,11 @@ namespace Cake.Terraform.Apply
                 builder.AppendSwitchQuoted("-var", $"{inputVariable.Key}={inputVariable.Value}");
             }
 
+            if (!settings.Input)
+            {
+                builder.AppendSwitch("-input", "=", settings.Input.ToString());
+            }
+
             Run(settings, builder);
         }
     }

--- a/src/Cake.Terraform/Apply/TerraformApplySettings.cs
+++ b/src/Cake.Terraform/Apply/TerraformApplySettings.cs
@@ -5,6 +5,11 @@ namespace Cake.Terraform.Apply
 {
     public class TerraformApplySettings : TerraformSettings
     {
+        public TerraformApplySettings()
+        {
+            this.Input = true;
+        }
+
         public int Parallelism { get; set; }
 
         public FilePath Plan { get; set; }
@@ -25,5 +30,11 @@ namespace Cake.Terraform.Apply
         /// https://www.terraform.io/docs/commands/apply.html#auto-approve
         /// </summary>
         public bool AutoApprove { get; set; }
+
+        /// <summary>
+        /// Ask for input for variables if not directly set.
+        /// <see>https://www.terraform.io/docs/commands/apply.html#input-true</see>
+        /// </summary>
+        public bool Input { get; set; }
     }
 }

--- a/src/Cake.Terraform/Init/TerraformInitRunner.cs
+++ b/src/Cake.Terraform/Init/TerraformInitRunner.cs
@@ -32,6 +32,16 @@ namespace Cake.Terraform.Init
                 builder.Append("-reconfigure");
             }
 
+            if (!settings.Input)
+            {
+                builder.AppendSwitch("-input", "=", settings.Input.ToString());
+            }
+
+            if (!settings.Backend)
+            {
+                builder.AppendSwitch("-backend", "=", settings.Backend.ToString());
+            }
+
             Run(settings, builder);
         }
     }

--- a/src/Cake.Terraform/Init/TerraformInitSettings.cs
+++ b/src/Cake.Terraform/Init/TerraformInitSettings.cs
@@ -4,6 +4,12 @@ namespace Cake.Terraform.Init
 {
     public class TerraformInitSettings : TerraformSettings
     {
+        public TerraformInitSettings()
+        {
+            this.Input = true;
+            this.Backend = true;
+        }
+
         /// <summary>
         /// A set of backend config key-value overrides to be passed to `terraform init`
         /// <see>https://www.terraform.io/docs/commands/init.html#backend-config-value</see>
@@ -22,5 +28,17 @@ namespace Cake.Terraform.Init
         /// <see>https://www.terraform.io/docs/commands/init.html#force-copy</see>
         /// </summary>
         public bool ForceCopy { get; set; }
+
+        /// <summary>
+        /// Ask for input if necessary. If false, will error if input was required.
+        /// <see>https://www.terraform.io/docs/commands/init.html#input-true</see>
+        /// </summary>
+        public bool Input { get; set; }
+
+        /// <summary>
+        /// Configure the backend for this configuration.
+        /// <see>https://www.terraform.io/docs/commands/init.html#backend-initialization</see>
+        /// </summary>
+        public bool Backend { get; set; }
     }
 }

--- a/src/Cake.Terraform/Plan/TerraformPlanRunner.cs
+++ b/src/Cake.Terraform/Plan/TerraformPlanRunner.cs
@@ -43,6 +43,11 @@ namespace Cake.Terraform.Plan
                 }
             }
 
+            if (!settings.Input)
+            {
+                builder.AppendSwitch("-input", "=", settings.Input.ToString());
+            }
+
             Run(settings, builder);
         }
 

--- a/src/Cake.Terraform/Plan/TerraformPlanSettings.cs
+++ b/src/Cake.Terraform/Plan/TerraformPlanSettings.cs
@@ -5,6 +5,11 @@ namespace Cake.Terraform.Plan
 {
     public class TerraformPlanSettings : TerraformSettings
     {
+        public TerraformPlanSettings()
+        {
+            this.Input = true;
+        }
+
         public FilePath OutFile { get; set; }
 
         public int Parallelism { get; set; }
@@ -24,5 +29,11 @@ namespace Cake.Terraform.Plan
         /// If set to true, generates a plan to destroy all the known resources
         /// </summary>
         public bool Destroy { get; set; }
+
+        /// <summary>
+        /// Ask for input for variables if not directly set.
+        /// <see>https://www.terraform.io/docs/commands/plan.html#input-true</see>
+        /// </summary>
+        public bool Input { get; set; }
     }
 }


### PR DESCRIPTION
## Description
- Added the `-input` switch to init, plan, apply settings
- Added the `-backend` switches to init settings

## Related Issue
#55 

## Motivation and Context
Adds missing switches

## How Has This Been Tested?
Wrote unit tests of course, then referenced the dll directly in one of my ADO builds that performs init with the backend disabled for template validation. The build packaged the cake scripts, along with the referenced dll, as an artifact that was then used to deploy to my development environment. During the deployment the init, plan, and apply tasks are executed. The behavior of the build and deployment was identical to manually adding the settings via `ArgumentCustomization = args =>`

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/545701/89957856-83f4e280-dc06-11ea-9ce1-babca7afe71a.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
