### PR TITLE
#57 Adding support for terraform validate command.

### DIFF
--- a/docs/input/docs/usage/examples.md
+++ b/docs/input/docs/usage/examples.md
@@ -144,3 +144,16 @@ Task("Destroy")
     TerraformDestroy(settings);
 });
 ```
+
+
+## TerraformValidate
+
+```csharp
+#addin Cake.Terraform
+
+Task("Validate")
+    .Does(() =>
+{
+    TerraformValidate();
+});
+```

--- a/src/Cake.Terraform.Tests/TerraformValidateTests.cs
+++ b/src/Cake.Terraform.Tests/TerraformValidateTests.cs
@@ -1,0 +1,97 @@
+﻿using System.Collections.Generic;
+using Cake.Core;
+using Cake.Terraform.Validate;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Terraform.Tests
+{
+    public class TerraformValidateTests
+    {
+        class Fixture : TerraformFixture<TerraformValidateSettings>
+        {
+            public Fixture(PlatformFamily platformFamily = PlatformFamily.Windows) : base(platformFamily) { }
+            
+            protected override void RunTool()
+            {
+                ProcessRunner.Process.SetStandardOutput(new List<string> { "default" });
+
+                var tool = new TerraformValidateRunner(FileSystem, Environment, ProcessRunner, Tools);
+
+                tool.Run(Settings);
+            }
+        }
+
+        public class TheExecutable
+        {
+            [Fact]
+            public void Should_throw_if_terraform_runner_was_not_found()
+            {
+                var fixture = new Fixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                var result = Record.Exception(() => fixture.Run());
+
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("Terraform: Could not locate executable.", result.Message);
+            }
+
+            [Theory]
+            [InlineData("/bin/tools/terraform/terraform.exe", "/bin/tools/terraform/terraform.exe")]
+            [InlineData("/bin/tools/terraform/terraform", "/bin/tools/terraform/terraform")]
+            public void Should_use_terraform_from_tool_path_if_provided(string toolPath, string expected)
+            {
+                var fixture = new Fixture() { Settings = { ToolPath = toolPath } };
+                fixture.GivenSettingsToolPathExist();
+
+                var result = fixture.Run();
+
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_find_terraform_if_tool_path_not_provided()
+            {
+                var fixture = new Fixture();
+
+                var result = fixture.Run();
+
+                Assert.Equal("/Working/tools/terraform.exe", result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_throw_if_process_has_a_non_zero_exit_code()
+            {
+                var fixture = new Fixture();
+                fixture.GivenProcessExitsWithCode(1);
+
+                var result = Record.Exception(() => fixture.Run());
+
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("Terraform: Process returned an error (exit code 1).", result.Message);
+            }
+
+            [Fact]
+            public void Should_find_linux_executable()
+            {
+                var fixture = new Fixture(PlatformFamily.Linux);
+                fixture.Environment.Platform.Family = PlatformFamily.Linux;
+
+
+                var result = fixture.Run();
+
+                Assert.Equal("/Working/tools/terraform", result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_set_workspace_and_list_parameter()
+            {
+                var fixture = new Fixture();
+
+                var result = fixture.Run();
+
+                Assert.Contains("validate", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Terraform/TerraformAliases.cs
+++ b/src/Cake.Terraform/TerraformAliases.cs
@@ -12,6 +12,7 @@ using Cake.Terraform.Output;
 using Cake.Terraform.Plan;
 using Cake.Terraform.Refresh;
 using Cake.Terraform.Show;
+using Cake.Terraform.Validate;
 
 namespace Cake.Terraform
 {
@@ -146,6 +147,19 @@ namespace Cake.Terraform
         public static void TerraformRefresh(this ICakeContext context, TerraformRefreshSettings settings)
         {
             var runner = new TerraformRefreshRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run(settings);
+        }
+
+        [CakeMethodAlias]
+        public static void TerraformValidate(this ICakeContext context)
+        {
+            TerraformValidate(context, new TerraformValidateSettings());
+        }
+
+        [CakeMethodAlias]
+        public static void TerraformValidate(this ICakeContext context, TerraformValidateSettings settings)
+        {
+            var runner = new TerraformValidateRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             runner.Run(settings);
         }
 

--- a/src/Cake.Terraform/Validate/TerraformValidateRunner.cs
+++ b/src/Cake.Terraform/Validate/TerraformValidateRunner.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+using Cake.Terraform.Init;
+
+namespace Cake.Terraform.Validate
+{
+    public class TerraformValidateRunner : TerraformRunner<TerraformValidateSettings>
+    {
+        public TerraformValidateRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools)
+            : base(fileSystem, environment, processRunner, tools)
+        {
+        }
+
+        public void Run(TerraformValidateSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder().Append("validate");
+
+
+            Run(settings, builder);
+        }
+    }
+
+    public class TerraformValidateSettings : TerraformSettings
+    {
+    }
+}


### PR DESCRIPTION
This adds support for the terraform validate command (#57 - https://www.terraform.io/docs/commands/validate.html).

## Motivation and Context
We wanted this feature so that we can do basic validation of our terraform scripts in our CI pipeline without having to do `StartProcess`.

## How Has This Been Tested?
Unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
